### PR TITLE
multiple window support added

### DIFF
--- a/js/lasttab.js
+++ b/js/lasttab.js
@@ -2,7 +2,7 @@
  * @author: Hasin Hayder [hasin_at_leevio_dot_com | http://hasin.me]
  * @license: MIT
  */
-var currentTab=0, oldTab=1, tabRemoved=false, oldWindow = 0, currentWindow = 0, singleTab = true;
+var currentTab=-1, oldTab=-1, tabRemoved=false, oldWindow = 0, currentWindow = 0, singleTab = true;
 
 chrome.tabs.onActivated.addListener(function(activeInfo) {
 	if(!tabRemoved){
@@ -45,7 +45,8 @@ chrome.commands.onCommand.addListener(function (command) {
 			currentWindow = tmp;
 		}
 
-    	chrome.tabs.update(oldTab,{selected:true}); //switch tab
+		if(oldTab!=-1) //at least two tabs didn't get focus yet, no way to switch then
+    		chrome.tabs.update(oldTab,{selected:true}); //switch tab
     }
 });
 

--- a/js/lasttab.js
+++ b/js/lasttab.js
@@ -2,7 +2,8 @@
  * @author: Hasin Hayder [hasin_at_leevio_dot_com | http://hasin.me]
  * @license: MIT
  */
-var currentTab=0, oldTab=1, tabRemoved=false;
+var currentTab=0, oldTab=1, tabRemoved=false, oldWindow = 0, currentWindow = 0, singleTab = true;
+
 chrome.tabs.onActivated.addListener(function(activeInfo) {
 	if(!tabRemoved){
 	//plain switch
@@ -16,17 +17,56 @@ chrome.tabs.onActivated.addListener(function(activeInfo) {
 		tabRemoved=false;
 	}
 
+	//if switched then update the window IDs
+	if(!singleTab)
+	{
+		oldWindow = currentWindow;
+		currentWindow = activeInfo.windowId;
+	}
+	else //Only single tab is active yet
+	{
+		oldWindow = currentWindow = activeInfo.windowId;
+		singleWindow = false;
+	}
+
 });
 
 //listen for the Alt + Z keypress event
 chrome.commands.onCommand.addListener(function (command) {
 	//alert(command);
 	if (command == "switch") {
-    	chrome.tabs.update(oldTab,{selected:true});
-    } 
+		if(currentWindow !== oldWindow) //Need switch on another window
+		{
+			chrome.windows.update(oldWindow, {focused: true}); //Get focus on the previous window
+
+			//update the window IDs
+			var tmp = oldWindow;
+			oldWindow = currentWindow;
+			currentWindow = tmp;
+		}
+
+    	chrome.tabs.update(oldTab,{selected:true}); //switch tab
+    }
+});
+
+
+//If an active window is removed, update the window IDs
+chrome.windows.onRemoved.addListener(function (winid) {
+
+	if(oldWindow === winid)
+	{
+		oldWindow = currentWindow;
+	}
+	else
+	{
+		currentWindow = oldWindow;
+	}
+
 });
 
 //listen when a tab is closed
 chrome.tabs.onRemoved.addListener(function(){
 	tabRemoved=true;
-})
+});
+
+


### PR DESCRIPTION
If more than one window is created in chrome, now it will also move from one window to another.
For the initial values of oldTab, and currentTab, switching without browsing less than two tabs throws error and shown in settings->extension page. That error also fixed.
